### PR TITLE
feat: add gallery component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 7,
+    "ecmaVersion": 9,
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": true
@@ -175,7 +175,7 @@
     "padded-blocks": [1, "never"],
     "quotes": [1, "single", "avoid-escape"],
     "quote-props": [1, "as-needed"],
-    "semi-spacing": ["error", {"before": false, "after": false}],
+    "semi-spacing": ["error", { "before": false, "after": false }],
     "semi-style": ["error", "last"],
     "semi": ["error", "never"],
     "keyword-spacing": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -18952,6 +18952,14 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-awesome-slider": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-awesome-slider/-/react-awesome-slider-4.1.0.tgz",
+      "integrity": "sha512-cbPI1MTpVLKbEH6gf9bwtJb8Ja6R/YJonKbUQehfq2B2AAJkgDMeHntaa4SgGCRqWd55xKiT+CkjfKau1QRsKw==",
+      "requires": {
+        "web-animation-club": "^0.6.0"
+      }
+    },
     "react-clientside-effect": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
@@ -23195,6 +23203,11 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "web-animation-club": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/web-animation-club/-/web-animation-club-0.6.0.tgz",
+      "integrity": "sha512-9W+EQu1HiaPLe/7WZlhJ2ULqQ4VL80RPDYW+ZcjfTKp6ayOuT1k3SVO6+tu0VBRmOqueJ/mrG+rjjInIv8Aglg=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
+    "react-awesome-slider": "^4.1.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1",
     "react-i18next": "^11.3.3",

--- a/src/components/Gallery/Gallery.stories.jsx
+++ b/src/components/Gallery/Gallery.stories.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import Gallery from './'
+import * as directors from '../../directors/directors.json'
+import { withKnobs, boolean, select, number } from '@storybook/addon-knobs'
+
+const images = directors.directors[1].gallery
+const imagesOptions = images.reduce(
+  (acc, currValue, index) => ({ ...acc, [currValue]: index }),
+  {}
+)
+
+export const SimpleGallery = () => (
+  <Gallery
+    infinite={boolean('infinite', false)}
+    fillParent={boolean('fillParent', false)}
+    bullets={boolean('bullets', true)}
+    organicArrows={boolean('organicArrows', true)}
+    selected={select('Active image', imagesOptions, 0)}
+    transitionDelay={number('Delay', 0)}
+    images={images.map(link => ({ src: link }))}
+  />
+)
+
+export default {
+  title: 'SimpleGallery',
+  decorators: [withKnobs]
+}

--- a/src/components/Gallery/index.jsx
+++ b/src/components/Gallery/index.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import AwesomeSlider from 'react-awesome-slider'
+import СoreStyles from 'react-awesome-slider/src/core/styles.scss'
+import AnimationStyles from 'react-awesome-slider/src/styled/fold-out-animation/fold-out-animation.scss'
+
+const Gallery = ({ images, ...rest }) => (
+  <AwesomeSlider
+    animation="foldOutAnimation"
+    cssModule={[СoreStyles, AnimationStyles]}
+    {...rest}
+  >
+    {images.length &&
+      images.map((image, index) => <div key={index} data-src={image.src} />)}
+  </AwesomeSlider>
+)
+
+Gallery.propTypes = {
+  images: PropTypes.arrayOf(
+    PropTypes.shape({
+      src: PropTypes.string
+    }).isRequired
+  )
+}
+
+export default Gallery

--- a/src/pages/architects.js
+++ b/src/pages/architects.js
@@ -21,6 +21,7 @@ const DirectorsPage = () => {
     }
   `)
   const [directorsArr] = data.allDirectorsJson.nodes.map(node => node.directors)
+  // eslint-disable-next-line array-bracket-spacing
   const [searchResults, setSearchResults] = React.useState(directorsArr)
   const getFiltered = value =>
     directorsArr.filter(


### PR DESCRIPTION
The gallery is taken from
https://github.com/rcaferati/react-awesome-slider
You can play with some props in storybook.
Also, we can consider to improve the design of arrows and choose other animations.

I could not commit without disabling eslint on
`const [searchResults, setSearchResults] = React.useState(directorsArr)`  in `architects` page